### PR TITLE
chore: bump const-module in lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2647,11 +2647,11 @@ __metadata:
   linkType: hard
 
 "const-module@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "const-module@npm:0.2.0"
+  version: 0.2.3
+  resolution: "const-module@npm:0.2.3"
   dependencies:
     tsx: ^4.7.1
-  checksum: 3f4c135c4e9c4f42d3d8aa4979f100d32295aa7373f7d451d16b5c73c78e6a4fe4465fe9df1f08d5d1d9da2b3c7c4069a1f190702ab3c8714deb2277e89e094a
+  checksum: 161e3614d3dab54e294a81790a0b1fe391aa896e8d5f359b61f826346126673301eac592ff53a04edb51fdd9fbd7df57cc619bee6d16bd9db2d6d701295f26b8
   languageName: node
   linkType: hard
 
@@ -9680,8 +9680,8 @@ __metadata:
   linkType: hard
 
 "tsx@npm:^4.7.1":
-  version: 4.7.1
-  resolution: "tsx@npm:4.7.1"
+  version: 4.7.2
+  resolution: "tsx@npm:4.7.2"
   dependencies:
     esbuild: ~0.19.10
     fsevents: ~2.3.3
@@ -9691,7 +9691,7 @@ __metadata:
       optional: true
   bin:
     tsx: dist/cli.mjs
-  checksum: 7f77294c0eee9a9b203f89eb299ee80b393d6b4bf79ec01b650502213a23ea08d0dfc52e938b302ef27c97b70557f7f5a590c3174a7e3c8f1140c668eea4a3a2
+  checksum: 34c4fbbfb96848e05e39d5c55da51815f0856386428ad781a6df79e88ad62d83e9a071a3997a230ea7b45654cb215262267ac1202c31b67056359d386f6a9f65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps `const-module` in the `yarn.lock` to allow the blog to be built on Windows.